### PR TITLE
Fix highlight of the first character under `#' and `//' comments

### DIFF
--- a/Syntaxes/Io.tmLanguage
+++ b/Syntaxes/Io.tmLanguage
@@ -107,7 +107,7 @@
 				</dict>
 			</dict>
 			<key>end</key>
-			<string>(?!\G)</string>
+			<string>(?&lt;=$\n)(?&lt;!\\$\n)</string>
 			<key>patterns</key>
 			<array>
 				<dict>

--- a/Syntaxes/Io.tmLanguage
+++ b/Syntaxes/Io.tmLanguage
@@ -74,7 +74,7 @@
 				</dict>
 			</dict>
 			<key>end</key>
-			<string>(?!\G)</string>
+			<string>(?&lt;=$\n)(?&lt;!\\$\n)</string>
 			<key>patterns</key>
 			<array>
 				<dict>


### PR DESCRIPTION
```io
#!/usr/bin/env io
"Hello world!" println
```
![0](https://user-images.githubusercontent.com/8097890/28248635-57ac11b8-6a7a-11e7-88a1-057efe20dbc5.png)
to
![1](https://user-images.githubusercontent.com/8097890/28248658-8d46daf6-6a7a-11e7-9e65-9379f186f3d7.png)


